### PR TITLE
Feature: closeInfoWindow

### DIFF
--- a/src/components/info-window.ts
+++ b/src/components/info-window.ts
@@ -86,7 +86,9 @@ export class InfoWindow implements OnInit, OnChanges, OnDestroy {
     this.infoWindow.setContent(this.template.element.nativeElement);
     this.infoWindow.open(this.nguiMapComponent.map, anchor);
   }
-
+  close(anchor: google.maps.MVCObject) {
+    this.infoWindow.close();
+  }
   ngOnDestroy() {
     this.inputChanges$.complete();
     if (this.infoWindow) {

--- a/src/components/info-window.ts
+++ b/src/components/info-window.ts
@@ -88,7 +88,7 @@ export class InfoWindow implements OnInit, OnChanges, OnDestroy {
   }
   close() {
     // check if infoWindow exists, and closes it
-    if(this.infoWindow)
+    if (this.infoWindow)
       this.infoWindow.close();
   }
   ngOnDestroy() {

--- a/src/components/info-window.ts
+++ b/src/components/info-window.ts
@@ -86,8 +86,10 @@ export class InfoWindow implements OnInit, OnChanges, OnDestroy {
     this.infoWindow.setContent(this.template.element.nativeElement);
     this.infoWindow.open(this.nguiMapComponent.map, anchor);
   }
-  close(anchor: google.maps.MVCObject) {
-    this.infoWindow.close();
+  close() {
+    // check if infoWindow exists, and closes it
+    if(this.infoWindow)
+      this.infoWindow.close();
   }
   ngOnDestroy() {
     this.inputChanges$.complete();

--- a/src/components/ngui-map.component.ts
+++ b/src/components/ngui-map.component.ts
@@ -175,11 +175,11 @@ export class NguiMapComponent implements OnChanges, OnDestroy, AfterViewInit, Af
   openInfoWindow(id: string, anchor: google.maps.MVCObject) {
     this.infoWindows[id].open(anchor);
   }
-  
-	closeInfoWindow(id: string) {
+
+  closeInfoWindow(id: string) {
     // if infoWindow for id exists, close the infoWindow
-    if(this.infoWindows[id])
-    	this.infoWindows[id].close();
+    if (this.infoWindows[id])
+      this.infoWindows[id].close();
   }
 
   ngOnDestroy() {

--- a/src/components/ngui-map.component.ts
+++ b/src/components/ngui-map.component.ts
@@ -175,6 +175,12 @@ export class NguiMapComponent implements OnChanges, OnDestroy, AfterViewInit, Af
   openInfoWindow(id: string, anchor: google.maps.MVCObject) {
     this.infoWindows[id].open(anchor);
   }
+  
+	closeInfoWindow(id: string, anchor: google.maps.MVCObject) {
+	  console.log(id);
+	  console.log(anchor);
+    	this.infoWindows[id].close(anchor);
+  }
 
   ngOnDestroy() {
     this.inputChanges$.complete();

--- a/src/components/ngui-map.component.ts
+++ b/src/components/ngui-map.component.ts
@@ -176,10 +176,10 @@ export class NguiMapComponent implements OnChanges, OnDestroy, AfterViewInit, Af
     this.infoWindows[id].open(anchor);
   }
   
-	closeInfoWindow(id: string, anchor: google.maps.MVCObject) {
-	  console.log(id);
-	  console.log(anchor);
-    	this.infoWindows[id].close(anchor);
+	closeInfoWindow(id: string) {
+    // if infoWindow for id exists, close the infoWindow
+    if(this.infoWindows[id])
+    	this.infoWindows[id].close();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
A closeInfoWindow function just like openInfoWindow function in nguimapcomponent which can be used to close the infowindow manually.
**Use Case:**
Close info window on `(mouseout)` of marker.
Eg:
```html
<marker (mouseover)="showInfoWindow($event)" (mouseout)="hideInfoWindow($event)"></marker>
```
```typescript
hideInfoWindow(event: any) {
let marker  = event.target;
marker.nguiMapComponent.closeInfoWindow(id);
}
```