### PR TITLE
Fixed bug that custom-markers won't open info-window

### DIFF
--- a/src/components/custom-marker.ts
+++ b/src/components/custom-marker.ts
@@ -173,6 +173,8 @@ export class CustomMarker implements OnInit, OnDestroy, OnChanges {
     // update object when input changes
     debounceTime.call(this.inputChanges$, 1000)
       .subscribe((changes: SimpleChanges) => this.nguiMap.updateGoogleObject(this.mapObject, changes));
+    
+    this.mapObject['nguiMapComponent'] = this.nguiMapComponent;
 
     this.nguiMapComponent.addToMapObjectGroup('CustomMarker', this.mapObject);
     this.initialized$.emit(this.mapObject);


### PR DESCRIPTION
Couldn't open info window from click event from custom-markers. This should fix the problem.