### PR TITLE
add option to specify debounceTime

### DIFF
--- a/src/components/ngui-map.component.ts
+++ b/src/components/ngui-map.component.ts
@@ -5,6 +5,7 @@ import {
   EventEmitter,
   SimpleChanges,
   Output,
+  Inject,
   NgZone,
   AfterViewInit, AfterViewChecked, OnChanges, OnDestroy
 } from '@angular/core';
@@ -18,6 +19,7 @@ import { InfoWindow } from './info-window';
 import { Subject } from 'rxjs/Subject';
 import { debounceTime } from 'rxjs/operator/debounceTime';
 import { toCamelCase } from '../services/util';
+import { NG_MAP_CONFIG_TOKEN, ConfigOption } from '../services/config';
 
 const INPUTS = [
   'backgroundColor', 'center', 'disableDefaultUI', 'disableDoubleClickZoom', 'draggable', 'draggableCursor',
@@ -79,6 +81,7 @@ export class NguiMapComponent implements OnChanges, OnDestroy, AfterViewInit, Af
     public nguiMap: NguiMap,
     public apiLoader: NgMapApiLoader,
     public zone: NgZone,
+    @Inject(NG_MAP_CONFIG_TOKEN) public config: ConfigOption,
   ) {
     apiLoader.load();
 
@@ -136,7 +139,7 @@ export class NguiMapComponent implements OnChanges, OnDestroy, AfterViewInit, Af
       });
 
       // update map when input changes
-      debounceTime.call(this.inputChanges$, 1000)
+      debounceTime.call(this.inputChanges$, typeof this.config.inputDebounceTime === 'number' ? this.config.inputDebounceTime : 1000)
         .subscribe((changes: SimpleChanges) => this.nguiMap.updateGoogleObject(this.map, changes));
 
       if (typeof window !== 'undefined' && (<any>window)['nguiMapRef']) {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -3,4 +3,5 @@ import { InjectionToken } from '@angular/core';
 export const NG_MAP_CONFIG_TOKEN = new InjectionToken<ConfigOption>('NG_MAP_CONFIG_TOKEN');
 export interface ConfigOption {
   apiUrl?: string;
+  inputDebounceTime?: number;
 }


### PR DESCRIPTION
IMO, component's input changes should not has debounceTime by default, or atleast not that much.

In my application, map center can be changed after clicking the provided locations and 1 second is too long for this kind of situation. So I created a PR for anyone who need a way to set or cancel debounceTime.

With this PR, developer can specify debounceTime value using the `ConfigOption` while importing NguiMapModule to application.

```typescript
@NgModule({
  imports: [
    ...
    NguiMapModule.forRoot({ apiUrl: 'https://maps.google.com/maps/api/js', inputDebounceTime: 0 })
  ],
})
export class MyModule { }
```

To maintain existing behavior, If `inputDebounceTime` is not specified, it will be 1000 ms just like before.

Hope this help,
Porawit Poboonma